### PR TITLE
Restrict GitHub PAT permissions to issues writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    permissions: write-all # This line is important for creating issues, should be on jobs or global
+    permissions:
+      issues: write
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
From what I can tell, this should be sufficient but please let me know if I missed anything.